### PR TITLE
Update docs on usage of `get-esm-packages` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Scan for ESM package to add to _remix.config.js_ `serverDependenciesToBundle`
 npx rmx-cli get-esm-packages [package-name ...]
 ```
 
+### Usage
+
+```bash
+  Example:
+    npx rmx-cli get-esm-packages @remix-run/node @remix-run/react
+```
+
 ## 🏷️ version
 
 List all Remix package versions installed in node_modules


### PR DESCRIPTION
Update docs to show an example of how to use `get-esm-packages` since some developer might not be aware of how to pass the list of arguments as package name.