### PR TITLE
fix: hardcoded sprite import

### DIFF
--- a/src/commands/svg-sprite.ts
+++ b/src/commands/svg-sprite.ts
@@ -104,11 +104,12 @@ function generateSprite(folder: string, files: string[]) {
 
 function generateReactComponent(spriteOutputFolder: string, files: string[]) {
   let icons = files.map(file => path.basename(file, '.svg'))
+  const spritePath = path.basename(outputFilename, '.tsx') + '.svg'
   let component =
     template ??
     `
 import { type SVGProps } from "react";
-import href from "./sprite.svg";
+import href from "./${spritePath}";
 export { href };
 
 export default function Icon({ icon, ...props}: SVGProps<SVGSVGElement> & { icon: IconName }) {


### PR DESCRIPTION
Previously, the generated component would only be able to import the `href` if the outputPath ended in `sprite.tsx`, for example:
```
npx rmx-cli svg-sprite assets/icons app/components/icons/sprite.tsx
```

With this change, the sprite href import matches the filename correctly for outputPath with and without the filename declared i.e.
```
npx rmx-cli svg-sprite assets/icons app/components/icons/foo.tsx
npx rmx-cli svg-sprite assets/icons app/components/icons/
```