### PR TITLE
Export string array of icon names and generate type union from it

### DIFF
--- a/src/commands/svg-sprite.ts
+++ b/src/commands/svg-sprite.ts
@@ -122,9 +122,11 @@ export default function Icon({ icon, ...props}: SVGProps<SVGSVGElement> & { icon
 `
   // add type IconName for each icon file
   component += `
-export type IconName =
-${icons.map(icon => `  | "${icon}"`).join('\n')}
-`
+export const iconNames = [
+${icons.map(icon => `  "${icon}",`).join('\n')}
+] as const;
+export type IconName = typeof iconNames[number];`
+
   icons.forEach(icon => console.log(`✅ ${icon}`))
 
   // if user wants named components, generate them


### PR DESCRIPTION
Creating a readonly string array of the icon names allows for other components in the app to access and iterate over all the icons and the type can be generated from it directly. 

My use case was displaying a grid of all the icons available in the app. Another example use case would be an Icon picker component. 