### PR TITLE
feat: add components-template option

### DIFF
--- a/src/commands/svg-sprite.ts
+++ b/src/commands/svg-sprite.ts
@@ -7,6 +7,7 @@ let rootFolder = ''
 let outputFolder = ''
 let template: string | null = null
 let namedComponents = false
+let componentsTemplate: string | null = null
 let component = 'icon.tsx'
 let sprite = 'icon.svg'
 let types = ''
@@ -35,6 +36,11 @@ export default function (args: string[]) {
         types = args[i].substring('--types='.length)
       } else if (args[i] === '--components') {
         namedComponents = true
+      } else if (args[i].startsWith('--components-template=')) {
+        const templateFilename = args[i].substring(
+          '--components-template='.length,
+        )
+        componentsTemplate = fs.readFileSync(templateFilename, 'utf8')
       }
     }
   } else {
@@ -215,14 +221,16 @@ export type IconName = typeof iconNames[number];`
 
   // if user wants named components, generate them
   if (namedComponents) {
-    output += '\n';
+    output += '\n'
     icons.forEach(icon => {
       // convert kebab case to title case
       const componentName = icon.replace(/(^|-|_)([a-z0-9])/g, g =>
         g!.at(-1)!.toUpperCase(),
       )
-      output += `
-export const ${componentName}Icon = (props: SVGProps<SVGSVGElement>) => <Icon icon="${icon}" {...props} />;`
+      output += '\n'
+      output +=
+          componentsTemplate?.replace(/{{icon}}/g, icon).replace(/{{componentName}}/g, componentName)
+          ?? `export const ${componentName}Icon = (props: SVGProps<SVGSVGElement>) => <Icon icon="${icon}" {...props} />;`
     })
   }
   const componentPath = path.join(spriteOutputFolder, component)


### PR DESCRIPTION
adds a new option for the svg-sprite command to specify a template to be used when creating components for each icon with the `components` option.

**Usage:**
`rmx svg-sprite <input> <output> --components --components-template=FILE`

the variables `{{componentName}}` and `{{icon}}` will be replaced.

**Example Template:**

`export const {{componentName}}Icon = (props: SVGProps<SVGSVGElement>) => <Icon icon="{{icon}}" {...props} />`

implements #21 